### PR TITLE
businessページの問い合わせフォームを/contactに一本化

### DIFF
--- a/_pages/business.md
+++ b/_pages/business.md
@@ -8,7 +8,7 @@ header:
   overlay_filter: rgba(35, 35, 35, 0.2)
   actions:
     - label: お問い合わせ
-      url: "/business/#お問い合わせ"
+      url: "/contact/"
 toc: true
 classes:
   - wide
@@ -126,7 +126,7 @@ NPO法人OVAL様の「SOSフィルター」のChrome拡張機能の開発を行�
 ### :v: その他
 
 上記のいずれにも該当しないようなものでも、気兼ねなくご相談ください。
-下記の[問い合わせフォーム](#お問い合わせフォーム)の「問い合わせ内容」に相談内容を明記してください。
+[問い合わせフォーム](/contact/)の「問い合わせ内容」に相談内容を明記してください。
 個人事業主を始めた目的の1つとして、自分の活動の幅を広げることとしています。
 私自身では思い浮かばないようなことで貢献できるご提案をいただけると、とても嬉しい限りです。
 
@@ -151,7 +151,7 @@ NPO法人OVAL様の「SOSフィルター」のChrome拡張機能の開発を行�
 
 ### 1. お問い合わせ
 
-[X（旧Twitter）](https://twitter.com/satoryuofficial)、[Facebookメッセンジャー](https://www.messenger.com/t/satoryu)、[メール](mailto:satoryu.1981@gmail.com)、または[問い合わせフォーム](#お問い合わせフォーム)からお問い合わせください。
+[X（旧Twitter）](https://twitter.com/satoryuofficial)、[Facebookメッセンジャー](https://www.messenger.com/t/satoryu)、[メール](mailto:satoryu.1981@gmail.com)、または[問い合わせフォーム](/contact/)からお問い合わせください。
 
 ### 2. 打ち合わせ（初回30分無料）
 
@@ -184,4 +184,9 @@ NPO法人OVAL様の「SOSフィルター」のChrome拡張機能の開発を行�
 
 ## お問い合わせ
 
-{% include inquiry_form.html %}
+ご相談やご依頼は、お問い合わせフォームからお願いいたします。
+初回のご相談（30分）は無料です。
+{: .text-center}
+
+[お問い合わせフォームへ](/contact/){: .btn .btn--success .btn--x-large}
+{: .text-center}

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -13,3 +13,9 @@ header:
 ベストエフォートですので予めご了承ください。
 
 {% include inquiry_form.html %}
+
+フォームが表示されない場合は、[こちらのページ](https://forms.office.com/r/JW9f3KfmRd)から直接ご入力ください。
+{: .text-center}
+
+[開発のご相談のページに戻る](/business/){: .btn .btn--inverse}
+{: .text-center}


### PR DESCRIPTION
## 背景

`/business` ページに Microsoft Forms が iframe で直接埋め込まれており、GA4 でフォームへの導線をイベントとして計測できなかった。iframe 内の操作は親ページ側から検知できないため。

計測性を改善するため、フォームは `/contact` に一本化し、`/business` からは通常の内部リンク（同一ドメインのページ遷移）で誘導する構成に変更する。

## 前提

`/contact` ページは既に存在しており、同じ `inquiry_form.html` を include していた。つまりフォームが2箇所に重複して埋め込まれていた状態のため、新規作成ではなく `/business` 側の重複を除去する形で対応している。

## 変更内容

### `_pages/business.md`

- 末尾の `{% raw %}{% include inquiry_form.html %}{% endraw %}` を CTA ボタンに置き換え（`index.md` と同じ `.btn .btn--success .btn--x-large` パターン、`target="_blank"` なし）
- ヘッダーの CTA ボタンの遷移先を `/business/#お問い合わせ` → `/contact/` に変更
- 本文中のリンク 2 箇所を `#お問い合わせフォーム` → `/contact/` に変更。この 2 つは元々アンカー名と実際の見出し（`お問い合わせ`）が不一致でリンク切れになっていたため、あわせて解消

### `_pages/contact.md`

- iframe が表示されない場合のフォールバックとして forms.office.com への直接リンクを追加
- `/business/` へ戻るリンクを `.btn--inverse`（テーマ標準のセカンダリボタン）で追加

## 確認したこと

`npm run lint` パス、`bundle exec jekyll build` 成功。ビルド出力とローカルサーバで以下を確認:

- `_site/business/index.html` に `forms.office.com` の出現は 0 件（iframe 除去済み）
- `/contact/` へのリンク 5 箇所すべてに `target` 属性なし → GA4 のセッションが継続する
- `_site/contact/index.html` に iframe・フォールバックリンク・戻るリンクが存在
- `sitemap.xml` に `/contact/` を確認（jekyll-sitemap による自動生成。`_data/navigation.yml` にも元から登録済み）

SPA ルーティングは該当なし。Jekyll の静的サイトで通常のフルページロード遷移のため、`page_view` は各ページロードで発火する。追加対応は不要。

## 対象外

GA4 側で `/contact` への `page_view` をキーイベントとして登録する設定は Google Analytics の管理画面上での作業のため、本 PR の対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SE7YmDjfFAmNKuW1R5xqLU